### PR TITLE
Update deps for gtk4, remove unneeded patches

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,7 +14,7 @@ _fragment="${FRAGMENT:-#branch=master}"
 : ${BITMAP_BACKEND:=imagemagick} # select imagemagick implementation {imagemagick,graphicsmagick}
 
 pkgname=inkscape-git
-pkgver=1.3.alpha.r987.g07fdc5641e
+pkgver=1.3.alpha.r1472.gae5f944810
 pkgrel=1
 epoch=5
 pkgdesc="An Open Source vector graphics editor, using SVG file format, from git master"
@@ -27,14 +27,13 @@ depends=(
 	'double-conversion'
 	'gc'
 	'gsl'
-	'gspell'
-	'gtkmm3'
-	'gtksourceview4'
+	'gtkmm-4.0'
+	'gtksourceview5'
 	'lcms2'
 	'lib2geom-git'
 	'libcdr'
 	'libjpeg-turbo'
-	'libsoup'
+	'libspelling'
 	'libvisio'
 	'libxslt'
 	'poppler-glib'
@@ -74,14 +73,6 @@ _gitname="inkscape.git"
 prepare() {
   cd  "$_gitname"
   prepare_submodule
-# fix track_obj deprecated in libsigc
-  sed '/DSIGCXX_DISABLE_DEPRECATED/d' -i CMakeScripts/DefineDependsandFlags.cmake
-# fix lib2geom header location
-  sed -E '/^#include/s/"(point.h)/"2geom\/\1/' -i src/path/splinefit/bezier-fit.cpp src/ui/{tool{/path-manipulator,s/object-picker-tool},dialog/{symbols,extensions-gallery}}.cpp
-# sed -E '/^#include/s/(forward.h)/2geom\/\1/' -i src/ui/tool/path-manipulator.cpp
-  sed -E '/^#include/s/"(rect.h)/"2geom\/\1/' -i src/ui/{dialog/{object-attributes,extensions-gallery},tools/object-picker-tool}.cpp
-  sed -E '/^#include/s/"(angle.h)/"2geom\/\1/' -i src/ui/dialog/document-properties.cpp
-  sed -E '/^#include/s/"(transforms.h)/"2geom\/\1/' -i src/ui/widget/gradient-editor.cpp
 }
 
 pkgver() {


### PR DESCRIPTION
* Update the dependencies to take account of the upstream gtk3->gtk4 port, making it build again.
* Remove unneeded dependencies (`libsoup`) and patching hacks (all of them).

~Marked as Draft because the `pkgver` still needs updating correctly. It should be `1.5-dev-something`, where I'm not sure how to generate the something. Furthermore I'm not sure whether affixing `-dev` will wreak havoc with the version ordering system when `-dev` comes to be replaced with `-alpha`.~

I've since realised that `pkgver` updates itself. That doesn't change the fact it's still wrong: it reports `1.3-alpha` when it should be `1.5-dev`. This is a separate issue though.

Fixes https://github.com/bartoszek/AUR-inkscape-git/issues/1